### PR TITLE
Allow shell flag for clients:create command

### DIFF
--- a/commands/clients/create.js
+++ b/commands/clients/create.js
@@ -15,9 +15,15 @@ function * run (context, heroku) {
       redirect_uri: url
     }
   })
-  let client = yield cli.action(`Creating ${context.args.name}`, request)
-  cli.log(`HEROKU_OAUTH_ID=${client.id}`)
-  cli.log(`HEROKU_OAUTH_SECRET=${client.secret}`)
+  if (context.flags.shell) {
+    let client = yield request
+    cli.log(`HEROKU_OAUTH_ID=${client.id}`)
+    cli.log(`HEROKU_OAUTH_SECRET=${client.secret}`)
+  } else {
+    let client = yield cli.action(`Creating ${context.args.name}`, request)
+    cli.log(`HEROKU_OAUTH_ID=${client.id}`)
+    cli.log(`HEROKU_OAUTH_SECRET=${client.secret}`)
+  }
 }
 
 module.exports = {
@@ -26,5 +32,8 @@ module.exports = {
   description: 'create a new OAuth client',
   needsAuth: true,
   args: [{name: 'name'}, {name: 'redirect_uri'}],
+  flags: [
+    {name: 'shell', char: 's', description: 'output in shell format'}
+  ],
   run: cli.command(co.wrap(run))
 }

--- a/commands/clients/create.js
+++ b/commands/clients/create.js
@@ -15,15 +15,14 @@ function * run (context, heroku) {
       redirect_uri: url
     }
   })
+  var client
   if (context.flags.shell) {
-    let client = yield request
-    cli.log(`HEROKU_OAUTH_ID=${client.id}`)
-    cli.log(`HEROKU_OAUTH_SECRET=${client.secret}`)
+    client = yield request
   } else {
-    let client = yield cli.action(`Creating ${context.args.name}`, request)
-    cli.log(`HEROKU_OAUTH_ID=${client.id}`)
-    cli.log(`HEROKU_OAUTH_SECRET=${client.secret}`)
+    client = yield cli.action(`Creating ${context.args.name}`, request)
   }
+  cli.log(`HEROKU_OAUTH_ID=${client.id}`)
+  cli.log(`HEROKU_OAUTH_SECRET=${client.secret}`)
 }
 
 module.exports = {


### PR DESCRIPTION
This allows the `--shell` and `-s` flags to be passed on the `clients:create` command again. This was working at some point, not sure when it stopped being a valid flag.